### PR TITLE
Feat/multiselect events on boxes

### DIFF
--- a/src/components/Box/BoxDraggable.js
+++ b/src/components/Box/BoxDraggable.js
@@ -1,6 +1,5 @@
 import React, { useRef } from 'react'
 import { observer } from 'mobx-react'
-import { getRandomColor } from '../../utils'
 import { useDraggableBox } from '../../hooks'
 
 export const BoxDraggable = observer((props) => {
@@ -14,7 +13,7 @@ export const BoxDraggable = observer((props) => {
     width,
     height,
     transform: `translate(${left}px, ${top}px)`,
-    border: isSelected ? `2px dotted ${getRandomColor()}` : 'none',
+    border: isSelected ? '3px dotted #424855FF' : 'none',
   }
 
   return (

--- a/src/components/Canvas/Canvas.js
+++ b/src/components/Canvas/Canvas.js
@@ -15,8 +15,7 @@ export const Canvas = observer(({ store }) => {
 
   const handleSelectBox = (event, box) => {
     event.stopPropagation()
-    if (store.selectBox) box.isSelected ? store.clearSelection() : store.selectBox(box)
-    else store.clearSelection()
+    box.isSelected ? store.clearSelection(box) : store.selectBox(box)
   }
 
   return (

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -5,7 +5,8 @@ import { showToast, TOAST } from '../../utils/toastMessages'
 import './Toolbar.css'
 
 export const Toolbar = observer(({ store }) => {
-  const { selectedBox, cursorPosition, boxes } = store;
+  const { selectedBoxes, cursorPosition, boxes } = store
+  const noSelectedBoxes = selectedBoxes.length === 0
 
   const handleAddButton = () => {
     const { x, y } = cursorPosition
@@ -18,26 +19,28 @@ export const Toolbar = observer(({ store }) => {
     const noBoxes = boxes.length === 0
 
     if (noBoxes) return showToast(TOAST.NO_BOXES)
-    if (!selectedBox) return showToast(TOAST.NO_SELECTED_BOX)
+    if (noSelectedBoxes) return showToast(TOAST.NO_SELECTED_BOXES)
 
-    store.removeBox(selectedBox)
-    showToast(TOAST.REMOVED_BOX)
+    store.removeSelection()
+    showToast(TOAST.REMOVED_BOXES)
   }
 
   const handleColorInput = (e) => {
-    if (!selectedBox) return showToast(TOAST.NO_SELECTED_BOX)
     const color = e.target.value
+    if (noSelectedBoxes) return showToast(TOAST.NO_SELECTED_BOXES)
 
-    store.selectedBox.changeColor(color)
+    store.setSelectionColor(color)
   }
+
+  // TODO handleSelectAllButton       <button onClick={handleSelectAllButton}>Toggle Boxes</button>
 
   return (
     <div className="toolbar">
       <ToastContainer />
       <button onClick={handleAddButton}>Add Box</button>
-      <button onClick={handleRemoveButton}>Remove Box</button>
-      <input type="color" onChange={handleColorInput} disabled={!selectedBox} />
-      <span>{selectedBox ? `${selectedBox.name} is selected` : 'No box selected'}</span>
+      <button onClick={handleRemoveButton}>Remove Boxes</button>
+      <input type="color" onChange={handleColorInput} disabled={selectedBoxes.length === 0} />
+      <span>{selectedBoxes.length > 0 ? `${selectedBoxes.length} boxes are selected` : 'No box selected'}</span>
     </div>
   )
 })

--- a/src/hooks/useDraggableBox/useDraggableBox.js
+++ b/src/hooks/useDraggableBox/useDraggableBox.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import interact from 'interactjs'
+import { store } from '../../stores/store'
 
 export const useDraggableBox = (boxRef, box) => {
   useEffect(() => {
@@ -12,12 +13,14 @@ export const useDraggableBox = (boxRef, box) => {
           restriction: 'parent',
         }),
       ],
+
       listeners: {
         move(event) {
-          const boxLeft = box.left + event.dx
-          const boxTop = box.top + event.dy
+          const { dx, dy } = event
+          const selfMove = () => box.move(box.left + dx, box.top + dy)
+          const groupMove = () => store.moveSelection(dx, dy)
 
-          box.move(boxLeft, boxTop)
+          box.isSelected ? groupMove() : selfMove()
         },
       },
     })

--- a/src/pages/Home/Home.test.js
+++ b/src/pages/Home/Home.test.js
@@ -68,14 +68,14 @@ describe('Home', () => {
 
     userEvent.dblClick(box)
 
-    const removeBoxButton = screen.getByText('Remove Box')
+    const removeBoxButton = screen.getByText('Remove Boxes')
     expect(removeBoxButton).toBeInTheDocument()
 
     userEvent.click(removeBoxButton)
 
     expect(screen.queryByText('Box 2')).not.toBeInTheDocument()
 
-    const toast = await screen.findByText('The box has been removed successfully')
+    const toast = await screen.findByText('Selected boxes have been removed successfully')
     expect(toast).toBeInTheDocument()
   })
 
@@ -98,7 +98,7 @@ describe('Home', () => {
     const box2 = screen.getByText('Box 2')
     expect(box2).toBeInTheDocument()
 
-    const removeBoxButton = screen.getByText('Remove Box')
+    const removeBoxButton = screen.getByText('Remove Boxes')
     expect(removeBoxButton).toBeInTheDocument()
 
     userEvent.dblClick(box1)
@@ -110,6 +110,40 @@ describe('Home', () => {
     userEvent.click(removeBoxButton)
 
     expect(screen.queryByText('Box 2')).not.toBeInTheDocument()
+  })
+
+  it('should remove two selected boxes in the canvas', async () => {
+    customRender(<Home />)
+
+    const canvas = screen.getByLabelText('canvas')
+    expect(canvas).toBeInTheDocument()
+
+    const box1 = screen.getByText('Box 1')
+    expect(box1).toBeInTheDocument()
+
+    userEvent.dblClick(box1)
+    userEvent.click(canvas)
+
+    const addBoxButton = screen.getByText('Add Box')
+    expect(addBoxButton).toBeInTheDocument()
+
+    userEvent.click(addBoxButton)
+
+    const box2 = screen.getByText('Box 2')
+    expect(box2).toBeInTheDocument()
+
+    userEvent.dblClick(box2)
+
+    const removeBoxButton = screen.getByText('Remove Boxes')
+    expect(removeBoxButton).toBeInTheDocument()
+
+    userEvent.click(removeBoxButton)
+
+    expect(screen.queryByText('Box 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Box 2')).not.toBeInTheDocument()
+
+    const toast = await screen.findByText('Selected boxes have been removed successfully')
+    expect(toast).toBeInTheDocument()
   })
 
   it('should display a message when no box is selected', async () => {
@@ -125,12 +159,12 @@ describe('Home', () => {
 
     userEvent.click(addBoxButton)
 
-    const removeBoxButton = screen.getByText('Remove Box')
+    const removeBoxButton = screen.getByText('Remove Boxes')
     expect(removeBoxButton).toBeInTheDocument()
 
     userEvent.click(removeBoxButton)
 
-    const toast = await screen.findByText('No box is selected')
+    const toast = await screen.findByText('No boxes are selected')
     expect(toast).toBeInTheDocument()
   })
 
@@ -143,7 +177,7 @@ describe('Home', () => {
     const box1 = screen.getByText('Box 1')
     expect(box1).toBeInTheDocument()
 
-    const removeBoxButton = screen.getByText('Remove Box')
+    const removeBoxButton = screen.getByText('Remove Boxes')
     expect(removeBoxButton).toBeInTheDocument()
 
     userEvent.dblClick(box1)

--- a/src/stores/actions/MainStoreActions.js
+++ b/src/stores/actions/MainStoreActions.js
@@ -28,6 +28,15 @@ export const MainStoreActions = (self) => {
     self.selectedBoxes.forEach((box) => box.changeColor(color))
   }
 
+  const moveSelection = (left, top) => {
+    self.selectedBoxes.forEach((box) => {
+      const boxLeft = box.left + left
+      const boxTop = box.top + top
+
+      box.move(boxLeft, boxTop)
+    })
+  }
+
   const saveToLocalStorage = () => {
     const currentState = getSnapshot(self)
     localStorage.setItem(MainStoreKey, JSON.stringify(currentState))
@@ -64,6 +73,7 @@ export const MainStoreActions = (self) => {
     clearSelection,
     removeSelection,
     setSelectionColor,
+    moveSelection,
     saveToLocalStorage,
     loadFromLocalStorage,
     initializeStore,

--- a/src/stores/actions/MainStoreActions.js
+++ b/src/stores/actions/MainStoreActions.js
@@ -9,17 +9,23 @@ export const MainStoreActions = (self) => {
     self.boxes.push(newBox)
   }
 
-  const removeBox = (box) => {
-    if (self.selectedBox === box) clearSelection()
-    self.boxes.remove(box)
-  }
-
   const selectBox = (box) => {
-    self.selectedBox = box
+    self.selectedBoxes.push(box)
   }
 
-  const clearSelection = () => {
-    self.selectedBox = null
+  const clearSelection = (box) => {
+    self.selectedBoxes.remove(box)
+  }
+
+  const removeSelection = () => {
+    self.selectedBoxes.slice().forEach((box) => {
+      self.selectedBoxes.remove(box)
+      self.boxes.remove(box)
+    })
+  }
+
+  const setSelectionColor = (color) => {
+    self.selectedBoxes.forEach((box) => box.changeColor(color))
   }
 
   const saveToLocalStorage = () => {
@@ -54,9 +60,10 @@ export const MainStoreActions = (self) => {
 
   return {
     addBox,
-    removeBox,
     selectBox,
     clearSelection,
+    removeSelection,
+    setSelectionColor,
     saveToLocalStorage,
     loadFromLocalStorage,
     initializeStore,

--- a/src/stores/models/Box.js
+++ b/src/stores/models/Box.js
@@ -15,7 +15,7 @@ export const BoxModel = types
       if (!hasParent(self)) return false
       const mainStore = getParent(self, 2)
 
-      return mainStore.selectedBox === self
+      return mainStore.selectedBoxes.includes(self)
     },
   }))
   .actions((self) => ({

--- a/src/stores/models/MainStore.js
+++ b/src/stores/models/MainStore.js
@@ -7,7 +7,7 @@ const MainStore = types
   .model('MainStore', {
     boxes: types.array(BoxModel),
     cursorPosition: types.optional(CursorPointerModel, { x: 0, y: 0 }),
-    selectedBox: types.maybeNull(types.reference(BoxModel)),
+    selectedBoxes: types.array(types.reference(BoxModel)),
   })
 
   .actions((self) => {

--- a/src/stores/store.test.js
+++ b/src/stores/store.test.js
@@ -19,7 +19,7 @@ describe('MainStore', () => {
     expect(store.boxes.length).toBe(1)
     expect(store.cursorPosition.x).toBe(0)
     expect(store.cursorPosition.y).toBe(0)
-    expect(store.selectedBox).toBeNull()
+    expect(store.selectedBoxes).toStrictEqual([])
     expect(store.boxes[0].name).toBe('Box 1')
   })
 
@@ -31,23 +31,39 @@ describe('MainStore', () => {
     expect(store.boxes[1].top).toBe(50)
   })
 
-  it('should remove a box', () => {
-    const box = store.boxes[0]
-    store.removeBox(box)
-    expect(store.boxes.length).toBe(0)
-  })
-
   it('should select a box', () => {
     const box = store.boxes[0]
     store.selectBox(box)
-    expect(store.selectedBox).toBe(box)
+    expect(store.selectedBoxes).toContain(box)
+  })
+
+  it('should not remove box when no selected boxes', () => {
+    store.removeSelection()
+    expect(store.boxes.length).toBe(1)
+  })
+
+  it('should remove a single selected box', () => {
+    const box = store.boxes[0]
+    store.selectBox(box)
+    store.removeSelection()
+    expect(store.boxes.length).toBe(0)
+  })
+
+  it('should remove selected boxes', () => {
+    store.addBox('Box 2', 50, 50)
+
+    const [box1, box2] = store.boxes
+    store.selectBox(box1)
+    store.selectBox(box2)
+    store.removeSelection()
+    expect(store.boxes.length).toBe(0)
   })
 
   it('should clear selection', () => {
     const box = store.boxes[0]
     store.selectBox(box)
-    store.clearSelection()
-    expect(store.selectedBox).toBeNull()
+    store.clearSelection(box)
+    expect(store.selectedBoxes).toStrictEqual([])
   })
 
   it('should persist and restore state from localStorage', () => {
@@ -61,7 +77,7 @@ describe('MainStore', () => {
   })
 
   it('should handle action listeners properly', () => {
-    jest.spyOn(store, 'saveToLocalStorage' )
+    jest.spyOn(store, 'saveToLocalStorage')
 
     const newStore = createMainStore()
     newStore.initializeStore()

--- a/src/test/storeSetup.js
+++ b/src/test/storeSetup.js
@@ -5,7 +5,7 @@ export const storeSetup = (initialState) => {
     initialState || {
       boxes: [],
       cursorPosition: { x: 0, y: 0 },
-      selectedBox: null,
+      selectedBoxes: [],
     }
   )
 }

--- a/src/utils/toastMessages.js
+++ b/src/utils/toastMessages.js
@@ -3,14 +3,14 @@ import 'react-toastify/dist/ReactToastify.css'
 
 export const TOAST = {
   NO_BOXES: 'NO_BOXES',
-  NO_SELECTED_BOX: 'NO_SELECTED_BOX',
-  REMOVED_BOX: 'REMOVED_BOX',
+  NO_SELECTED_BOXES: 'NO_SELECTED_BOXES',
+  REMOVED_BOXES: 'REMOVED_BOXES',
 }
 
 const MESSAGES = {
   NO_BOXES: 'There are no boxes to remove',
-  NO_SELECTED_BOX: 'No box is selected',
-  REMOVED_BOX: 'The box has been removed successfully',
+  NO_SELECTED_BOXES: 'No boxes are selected',
+  REMOVED_BOXES: 'Selected boxes have been removed successfully',
 }
 
 export function showToast(key) {


### PR DESCRIPTION
## 🎯 Goal
- Multiple boxes can be visually selected
- Multiple boxes can be removed at once
- Multiple boxes can be dragged at once
- The color on multiple boxes can be changed at once

### 📍Specifications
- When dragging a group of selected boxes by clicking on a selected box, all the selected boxes are dragged as group
- When dragging a single selected box, only this box is dragged through the canvas
- When dragging over an unselected box, only this box is dragged through the canvas
(Check video below)

### 🧪 Included test
- [x] YES, how dare you?
- [ ] NO, what do you mean with tests?

### 📸 Evidences

https://github.com/user-attachments/assets/6209926a-9f51-4111-83e2-8d7c6355f1ad


