### PR TITLE
feat: undo & redo actions

### DIFF
--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -32,14 +32,23 @@ export const Toolbar = observer(({ store }) => {
     store.setSelectionColor(color)
   }
 
-  // TODO handleSelectAllButton       <button onClick={handleSelectAllButton}>Toggle Boxes</button>
+
+  const handleUndoButton = () => {
+    store.undo()
+  }
+
+  const handleRedoButton = () => {
+    store.redo()
+  }
 
   return (
     <div className="toolbar">
       <ToastContainer />
       <button onClick={handleAddButton}>Add Box</button>
       <button onClick={handleRemoveButton}>Remove Boxes</button>
-      <input type="color" onChange={handleColorInput} disabled={selectedBoxes.length === 0} />
+      <button onClick={handleUndoButton}>Undo</button>
+      <button onClick={handleRedoButton}>Redo</button>
+      <input type="color" onChange={handleColorInput} disabled={noSelectedBoxes} />
       <span>{selectedBoxes.length > 0 ? `${selectedBoxes.length} boxes are selected` : 'No box selected'}</span>
     </div>
   )

--- a/src/stores/actions/MainStoreActions.js
+++ b/src/stores/actions/MainStoreActions.js
@@ -1,5 +1,6 @@
 import { getSnapshot, onAction } from 'mobx-state-tree'
 import { createBox } from './BoxActions'
+import { undoManager } from '../models/MainStore'
 
 export const MainStoreKey = 'MainStore'
 
@@ -29,11 +30,13 @@ export const MainStoreActions = (self) => {
   }
 
   const moveSelection = (left, top) => {
-    self.selectedBoxes.forEach((box) => {
-      const boxLeft = box.left + left
-      const boxTop = box.top + top
+    undoManager.withoutUndo(() => {
+      self.selectedBoxes.forEach((box) => {
+        const boxLeft = box.left + left
+        const boxTop = box.top + top
 
-      box.move(boxLeft, boxTop)
+        box.move(boxLeft, boxTop)
+      })
     })
   }
 
@@ -59,6 +62,14 @@ export const MainStoreActions = (self) => {
     }
   }
 
+  const undo = () => {
+    if (undoManager.canUndo) undoManager.undo()
+  }
+
+  const redo = () => {
+    if (undoManager.canRedo) undoManager.redo()
+  }
+
   const setupActionListener = () => {
     onAction(self, (call) => {
       if (call.type !== 'saveToLocalStorage') {
@@ -77,6 +88,8 @@ export const MainStoreActions = (self) => {
     saveToLocalStorage,
     loadFromLocalStorage,
     initializeStore,
+    undo,
+    redo,
     setupActionListener,
   }
 }

--- a/src/stores/models/MainStore.js
+++ b/src/stores/models/MainStore.js
@@ -1,4 +1,5 @@
 import { types } from 'mobx-state-tree'
+import { UndoManager } from 'mst-middlewares'
 import { CursorPointerModel } from './CursorPointer'
 import { BoxModel } from './Box'
 import { MainStoreActions } from '../actions/MainStoreActions'
@@ -8,19 +9,23 @@ const MainStore = types
     boxes: types.array(BoxModel),
     cursorPosition: types.optional(CursorPointerModel, { x: 0, y: 0 }),
     selectedBoxes: types.array(types.reference(BoxModel)),
+    history: types.optional(UndoManager, {}),
   })
 
   .actions((self) => {
     const actions = MainStoreActions(self)
     const { setupActionListener, initializeStore } = actions
+    const setUndoManager = () => (undoManager = self.history)
 
     return {
       ...actions,
       afterCreate() {
         initializeStore()
+        setUndoManager()
         setupActionListener()
       },
     }
   })
 
+export let undoManager = {}
 export const createMainStore = () => MainStore.create()


### PR DESCRIPTION
## 🎯 Goal
- Undo and Redo actions

### 📍Specifications
- Dragging is omitted from the feature on purpose using` undoManager.withoutUndo()`.
- To simplify the feature, events are only applied in Main Store

### 🧪 Included test
- [] YES, how dare you?
- [x] NO, what do you mean with tests?

### 📸 Evidences

https://github.com/user-attachments/assets/2867fa92-94eb-40f3-943e-37dfbb3a4c4e


